### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/K21-sample/e7ae4ac0-1fc1-42a2-b7da-9d6611ec5f2c/fea235e1-3ea8-460c-8eb0-8cd743bd817a/_apis/work/boardbadge/687db022-58b9-4049-807e-560d710d6e9b)](https://dev.azure.com/K21-sample/e7ae4ac0-1fc1-42a2-b7da-9d6611ec5f2c/_boards/board/t/fea235e1-3ea8-460c-8eb0-8cd743bd817a/Microsoft.RequirementCategory)
 #Demo File


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#7. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.